### PR TITLE
Updating the podspec to be valid to push to Cocoapods Trunk

### DIFF
--- a/SIOSocket.podspec
+++ b/SIOSocket.podspec
@@ -7,4 +7,6 @@ Pod::Spec.new do |s|
     s.platform      = :ios, "7.0"
     s.source_files  = "SocketIO/Source/*.{h,m}"
     s.requires_arc  = true
+    s.homepage      = "https://github.com/MegaBits/SIOSocket"
+    s.authors       = { "Patrick Perini" => "pcperini@gmail.com" }
 end


### PR DESCRIPTION
These attributes in the podspec file are required to push to the Cocoapods trunk.
Do you think you could push to the trunk?

This means we'd be able to add your library as a dependency and not just add it as a normal pod.

Thank you for your consideration,
Ben
