### PR TITLE
Adding close method.

### DIFF
--- a/SocketIO/Source/SIOSocket.h
+++ b/SocketIO/Source/SIOSocket.h
@@ -28,4 +28,6 @@
 // Emitters
 - (void)emit:(NSString *)event, ... NS_REQUIRES_NIL_TERMINATION;
 
+- (void)close;
+
 @end

--- a/SocketIO/Source/SIOSocket.m
+++ b/SocketIO/Source/SIOSocket.m
@@ -151,4 +151,11 @@
     [self.javascriptContext evaluateScript: [NSString stringWithFormat: @"objc_socket.emit(%@);", [arguments componentsJoinedByString: @", "]]];
 }
 
+- (void)close
+{
+    [self.javascriptWebView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"about:blank"]]];
+    [self.javascriptWebView reload];
+    self.javascriptWebView = nil;
+}
+
 @end


### PR DESCRIPTION
This close method is useful to destroy contextual UIWebView which is keeping an open socket even if we are instantiating a new SIOSocket.
