### PR TITLE
Threading fixes

### DIFF
--- a/SocketIO/Source/SIOSocket.h
+++ b/SocketIO/Source/SIOSocket.h
@@ -27,6 +27,7 @@ typedef NSArray SIOParameterArray;
 
 // Event responders
 @property (nonatomic, copy) void (^onConnect)();
+@property (nonatomic, copy) void (^onConnectError)(NSDictionary *errorInfo);
 @property (nonatomic, copy) void (^onDisconnect)();
 @property (nonatomic, copy) void (^onError)(NSDictionary *errorInfo);
 

--- a/SocketIO/Source/SIOSocket.m
+++ b/SocketIO/Source/SIOSocket.m
@@ -182,7 +182,9 @@ static NSString *SIOMD5(NSString *string) {
         }
     }
     
-    [self performSelector:@selector(evaluateArguments:) onThread:self.thread withObject:[arguments copy] waitUntilDone:YES];
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
+        [self performSelector:@selector(evaluateArguments:) onThread:self.thread withObject:[arguments copy] waitUntilDone:YES];
+    });
 }
 
 - (void)evaluateArguments:(NSArray *)args {

--- a/SocketIO/Source/SIOSocket.m
+++ b/SocketIO/Source/SIOSocket.m
@@ -174,7 +174,11 @@ static NSString *SIOMD5(NSString *string) {
             [arguments addObject: [NSString stringWithFormat: @"blob('%@')", dataString]];
         }
         else if ([arg isKindOfClass: [NSArray class]] || [arg isKindOfClass: [NSDictionary class]]) {
-            [arguments addObject: [[NSString alloc] initWithData: [NSJSONSerialization dataWithJSONObject: arg options: 0 error: nil] encoding: NSUTF8StringEncoding]];
+            if ([NSJSONSerialization isValidJSONObject:arg]) {
+                [arguments addObject: [[NSString alloc] initWithData: [NSJSONSerialization dataWithJSONObject: arg options: 0 error: nil] encoding: NSUTF8StringEncoding]];
+            } else {
+                NSLog(@"SIOSocket serialization error at %@", NSStringFromSelector(_cmd));
+            }
         }
     }
     

--- a/SocketIO/Source/SIOSocket.m
+++ b/SocketIO/Source/SIOSocket.m
@@ -53,7 +53,9 @@ static NSString *SIOMD5(NSString *string) {
 + (void)socketWithHost:(NSString *)hostURL reconnectAutomatically:(BOOL)reconnectAutomatically attemptLimit:(NSInteger)attempts withDelay:(NSTimeInterval)reconnectionDelay maximumDelay:(NSTimeInterval)maximumDelay timeout:(NSTimeInterval)timeout response:(void (^)(SIOSocket *))response {
     SIOSocket *socket = [[SIOSocket alloc] init];
     if (!socket) {
-        response(nil);
+        dispatch_async(dispatch_get_main_queue(), ^{
+            response(nil);
+        });
         return;
     }
 
@@ -78,39 +80,53 @@ static NSString *SIOMD5(NSString *string) {
 
         socket.javascriptContext[@"objc_socket"] = [socket.javascriptContext evaluateScript: socketConstructor];
         if (![socket.javascriptContext[@"objc_socket"] toObject]) {
-            response(nil);
+            dispatch_async(dispatch_get_main_queue(), ^{
+                response(nil);
+            });
         }
 
         // Responders
         __weak typeof(socket) weakSocket = socket;
         socket.javascriptContext[@"objc_onConnect"] = ^() {
-            if (weakSocket.onConnect)
-                weakSocket.onConnect();
+            dispatch_async(dispatch_get_main_queue(), ^{
+                if (weakSocket.onConnect)
+                    weakSocket.onConnect();
+            });
         };
 
         socket.javascriptContext[@"objc_onDisconnect"] = ^() {
-            if (weakSocket.onDisconnect)
-                weakSocket.onDisconnect();
+            dispatch_async(dispatch_get_main_queue(), ^{
+                if (weakSocket.onDisconnect)
+                    weakSocket.onDisconnect();
+            });
         };
 
         socket.javascriptContext[@"objc_onError"] = ^(NSDictionary *errorDictionary) {
-            if (weakSocket.onError)
-                weakSocket.onError(errorDictionary);
+            dispatch_async(dispatch_get_main_queue(), ^{
+                if (weakSocket.onError)
+                    weakSocket.onError(errorDictionary);
+            });
         };
 
         socket.javascriptContext[@"objc_onReconnect"] = ^(NSInteger numberOfAttempts) {
-            if (weakSocket.onReconnect)
-                weakSocket.onReconnect(numberOfAttempts);
+            dispatch_async(dispatch_get_main_queue(), ^{
+                if (weakSocket.onReconnect)
+                    weakSocket.onReconnect(numberOfAttempts);
+            });
         };
 
         socket.javascriptContext[@"objc_onReconnectionAttempt"] = ^(NSInteger numberOfAttempts) {
-            if (weakSocket.onReconnectionAttempt)
-                weakSocket.onReconnectionAttempt(numberOfAttempts);
+            dispatch_async(dispatch_get_main_queue(), ^{
+                if (weakSocket.onReconnectionAttempt)
+                    weakSocket.onReconnectionAttempt(numberOfAttempts);
+            });
         };
 
         socket.javascriptContext[@"objc_onReconnectionError"] = ^(NSDictionary *errorDictionary) {
-            if (weakSocket.onReconnectionError)
-                weakSocket.onReconnectionError(errorDictionary);
+            dispatch_async(dispatch_get_main_queue(), ^{
+                if (weakSocket.onReconnectionError)
+                    weakSocket.onReconnectionError(errorDictionary);
+            });
         };
 
         [socket.javascriptContext evaluateScript: @"objc_socket.on('connect', objc_onConnect);"];
@@ -120,7 +136,9 @@ static NSString *SIOMD5(NSString *string) {
         [socket.javascriptContext evaluateScript: @"objc_socket.on('reconnecting', objc_onReconnectionAttempt);"];
         [socket.javascriptContext evaluateScript: @"objc_socket.on('reconnect_error', objc_onReconnectionError);"];
 
-        response(socket);
+        dispatch_async(dispatch_get_main_queue(), ^{
+            response(socket);
+        });
     };
         
     [socket.javascriptWebView loadHTMLString: @"<html/>" baseURL: nil];
@@ -146,10 +164,13 @@ static NSString *SIOMD5(NSString *string) {
             }
         }
         
-        function(arguments);
+        dispatch_async(dispatch_get_main_queue(), ^{
+            function(arguments);
+        });
     };
     
-    [self.javascriptContext evaluateScript: [NSString stringWithFormat: @"objc_socket.on('%@', objc_%@);", event, eventID]];
+    NSString* script = [NSString stringWithFormat: @"objc_socket.on('%@', objc_%@);", event, eventID];
+    [self performSelector:@selector(evaluateScript:) onThread:_thread withObject:[script copy] waitUntilDone:NO];
 }
 
 // Emitters
@@ -181,14 +202,14 @@ static NSString *SIOMD5(NSString *string) {
             }
         }
     }
-    
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
-        [self performSelector:@selector(evaluateArguments:) onThread:self.thread withObject:[arguments copy] waitUntilDone:YES];
-    });
+
+    NSString* script = [NSString stringWithFormat: @"objc_socket.emit(%@);", [args componentsJoinedByString: @", "]];
+    [self performSelector:@selector(evaluateScript:) onThread:_thread withObject:[script copy] waitUntilDone:NO];
 }
 
-- (void)evaluateArguments:(NSArray *)args {
-    [self.javascriptContext evaluateScript: [NSString stringWithFormat: @"objc_socket.emit(%@);", [args componentsJoinedByString: @", "]]];
+- (void)evaluateScript:(NSString *)script {
+    NSLog(@"socket evaluate script: %@", script);
+    [self.javascriptContext evaluateScript:script];
 }
 
 - (void)close {

--- a/SocketIO/Source/SIOSocket.m
+++ b/SocketIO/Source/SIOSocket.m
@@ -93,6 +93,13 @@ static NSString *SIOMD5(NSString *string) {
                     weakSocket.onConnect();
             });
         };
+        
+        socket.javascriptContext[@"objc_onConnectError"] = ^(NSDictionary *errorDictionary) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                if (weakSocket.onConnectError)
+                    weakSocket.onConnectError(errorDictionary);
+            });
+        };
 
         socket.javascriptContext[@"objc_onDisconnect"] = ^() {
             dispatch_async(dispatch_get_main_queue(), ^{
@@ -203,12 +210,11 @@ static NSString *SIOMD5(NSString *string) {
         }
     }
 
-    NSString* script = [NSString stringWithFormat: @"objc_socket.emit(%@);", [args componentsJoinedByString: @", "]];
+    NSString* script = [NSString stringWithFormat: @"objc_socket.emit(%@);", [arguments componentsJoinedByString: @", "]];
     [self performSelector:@selector(evaluateScript:) onThread:_thread withObject:[script copy] waitUntilDone:NO];
 }
 
 - (void)evaluateScript:(NSString *)script {
-    NSLog(@"socket evaluate script: %@", script);
     [self.javascriptContext evaluateScript:script];
 }
 


### PR DESCRIPTION
Builds on @zulkis pull request #42 to fix threading issues #16, #36. 

We store the thread created by the javascriptContext to use when calling evaluateScript, so that all calls to evaluateScript are on the same thread.

Also all callbacks are run against the main thread to ensure thread safety.